### PR TITLE
Fix parseVectorString and finalize embedding service

### DIFF
--- a/lib/embeddings/client/embeddingService.ts
+++ b/lib/embeddings/client/embeddingService.ts
@@ -236,4 +236,4 @@ export class ClientEmbeddingService {
 }
 
 // Create a singleton instance
-export const clientEmbeddingService = new ClientEmbeddingService() 
+export const clientEmbeddingService = new ClientEmbeddingService();

--- a/lib/vector/vectorUtils.ts
+++ b/lib/vector/vectorUtils.ts
@@ -319,12 +319,13 @@ export function normalizeVector(vec: number[]): number[] {
  */
 export function parseVectorString(vectorStr: string): number[] {
   if (!vectorStr) return [];
-  
+
   return vectorStr
     .split(",")
-    .map(s => s.trim())
-    .filter(s => s.length > 0)
-    .map(s => parseFloat(s));
+    .map((s) => s.trim())
+    .filter((s) => s.length > 0)
+    .map((s) => parseFloat(s))
+    .filter((n) => !Number.isNaN(n));
 }
 
 /**


### PR DESCRIPTION
## Summary
- ensure parseVectorString ignores non-numeric values
- add missing semicolon and newline in embedding service export

## Testing
- `npm run lint` *(fails: next not found)*
- `npx tsc -p tsconfig.json` *(fails: missing dependencies)*