### PR TITLE
Enable VSIM WITHATTRIBS support

### DIFF
--- a/app/api/redis/command/vsim/command.ts
+++ b/app/api/redis/command/vsim/command.ts
@@ -55,6 +55,7 @@ export function validateVsimRequest(body: any): { isValid: boolean; error?: stri
             filterExplorationFactor: body.filterExplorationFactor,
             returnCommandOnly: body.returnCommandOnly === true,
             withEmbeddings: body.withEmbeddings === true,
+            withAttributes: body.withAttributes === true,
             forceLinearScan: body.forceLinearScan === true,
             noThread: body.noThread === true
         }
@@ -81,6 +82,11 @@ export function buildVsimCommand(request: VsimRequestBody): string[][] {
 
     // Always add WITHSCORES for consistent result format
     baseCommand.push("WITHSCORES")
+
+    // Include attributes directly from VSIM if requested
+    if (request.withAttributes) {
+        baseCommand.push("WITHATTRIBS")
+    }
 
     // Add count
     baseCommand.push("COUNT", String(request.count))

--- a/app/api/redis/command/vsim/route.ts
+++ b/app/api/redis/command/vsim/route.ts
@@ -3,9 +3,9 @@ import { RedisConnection, getRedisUrl } from '@/lib/redis-server/RedisConnection
 import { validateVsimRequest, buildVsimCommand } from './command'
 import { formatResponse } from '@/lib/redis-server/utils'
 import { fetchEmbeddingsBatch } from '@/app/api/redis/command/vemb_multi/command'
+import { VsimResult } from '@/lib/redis-server/api'
 
-type SimPair = [string, number];
-type SimPairWithEmb = [string, number, number[] | null];
+type BasePair = { id: string; score: number; attributes: string | null };
 
 export async function POST(request: Request) {
     try {
@@ -44,24 +44,39 @@ export async function POST(request: Request) {
             return formatResponse(redisResult)
         }
 
-        // Process the result into pairs of [element, score]
-        const pairs: SimPair[] = []
+        // Process the result into pairs including optional attributes
+        const pairs: BasePair[] = []
         const resultArray = redisResult.result as string[]
-        for (let i = 0; i < resultArray.length; i += 2) {
-            pairs.push([resultArray[i], parseFloat(resultArray[i + 1])])
+
+        const step = validationResult.value.withAttributes ? 3 : 2
+
+        for (let i = 0; i < resultArray.length; i += step) {
+            const id = resultArray[i]
+            const score = parseFloat(resultArray[i + 1])
+            const attrib = validationResult.value.withAttributes
+                ? (resultArray[i + 2] ?? null)
+                : null
+            pairs.push({ id, score, attributes: attrib })
         }
 
         // If withEmbeddings is requested, fetch them for all elements
-        let finalResult: SimPair[] | SimPairWithEmb[] = pairs
+        let finalResult: VsimResult = pairs.map((p) => [p.id, p.score, null, p.attributes])
         if (validationResult.value.withEmbeddings) {
             console.log("VSIM GET embeddings")
-            const elements = pairs.map(([id]) => id)
-            const embResults = await fetchEmbeddingsBatch(redisUrl, validationResult.value.keyName, elements)
+            const elements = pairs.map((p) => p.id)
+            const embResults = await fetchEmbeddingsBatch(
+                redisUrl,
+                validationResult.value.keyName,
+                elements
+            )
 
             if (embResults.success && embResults.result) {
-                finalResult = pairs.map(([id, score], index): SimPairWithEmb => 
-                    [id, score, embResults.result![index]]
-                )
+                finalResult = pairs.map((p, index) => [
+                    p.id,
+                    p.score,
+                    embResults.result![index],
+                    p.attributes,
+                ])
             }
         }
 

--- a/app/vectorset/hooks/useFilterAttributes.ts
+++ b/app/vectorset/hooks/useFilterAttributes.ts
@@ -1,143 +1,34 @@
 import { useEffect, useState } from "react"
-import { VectorTuple, vgetattr_multi } from "@/lib/redis-server/api"
+import { VectorTuple } from "@/lib/redis-server/api"
 
 export default function useFilterAttributes(
     results: VectorTuple[],
-    filterValue: string,
-    vectorSetName?: string
+    filterValue: string
 ) {
     const [availableAttributes, setAvailableAttributes] = useState<string[]>([])
-    const [isLoadingAttributes, setIsLoadingAttributes] = useState(false)
 
-    // Extract available attributes from search results
     useEffect(() => {
-        const fetchAttributes = async () => {
-            if (!results || results.length === 0 || !vectorSetName) {
-                return
-            }
+        const attrs = new Set<string>()
 
-            setIsLoadingAttributes(true)
-            const attributes = new Set<string>()
-
-            try {
-                // Extract elements from results
-                const elements = results.map((result) => result[0])
-
-                // Fetch attributes using vgetattr_multi
-                const response = await vgetattr_multi({
-                    keyName: vectorSetName,
-                    elements,
-                    returnCommandOnly: false,
-                })
-                if (!response || !response.success) {
-                    return
-                }
-                const attributesResults = response.result
-
-                if (attributesResults && attributesResults.length > 0) {
-                    // Process each attribute JSON string
-                    attributesResults.forEach((attributeJson) => {
-                        if (attributeJson) {
-                            try {
-                                const attributeObj = JSON.parse(attributeJson)
-
-                                if (
-                                    attributeObj &&
-                                    typeof attributeObj === "object"
-                                ) {
-                                    Object.keys(attributeObj).forEach((key) => {
-                                        attributes.add(key)
-                                    })
-                                }
-                            } catch (error) {
-                                console.error(
-                                    "Error parsing attribute JSON:",
-                                    error
-                                )
-                            }
-                        }
-                    })
-                }
-            } catch (error) {
-                console.error("Error fetching attributes:", error)
-                // Fallback: try to extract from the results directly
-                extractAttributesFromResults(results, attributes)
-            }
-
-            // Add manually discovered attributes from filter input
-            const filterMatches =
-                filterValue.match(/\.([a-zA-Z_][a-zA-Z0-9_]*)/g) || []
-            filterMatches.forEach((match) => {
-                const attr = match.substring(1) // Remove the leading dot
-                attributes.add(attr)
-            })
-
-            const attributesArray = Array.from(attributes)
-            setAvailableAttributes(attributesArray)
-            setIsLoadingAttributes(false)
-        }
-
-        fetchAttributes()
-    }, [results, filterValue, vectorSetName])
-
-    return { availableAttributes, isLoadingAttributes }
-}
-
-// Helper function to extract attributes from results directly (fallback)
-function extractAttributesFromResults(
-    results: VectorTuple[],
-    attributes: Set<string>
-) {
-    results.forEach((result) => {
-        // VectorTuple format: [element, score, vector?, attributes?]
-        // The attributes are in the 4th position (index 3)
-        if (result && result.length >= 4) {
-            const attributesData = result[3]
-
-            if (typeof attributesData === "string") {
+        results.forEach((result) => {
+            const attrStr = result[3]
+            if (attrStr) {
                 try {
-                    const attributesObj = JSON.parse(attributesData)
-
-                    if (
-                        attributesObj &&
-                        typeof attributesObj === "object"
-                    ) {
-                        Object.keys(attributesObj).forEach((key) => {
-                            attributes.add(key)
-                        })
+                    const obj = JSON.parse(attrStr)
+                    if (obj && typeof obj === "object") {
+                        Object.keys(obj).forEach((k) => attrs.add(k))
                     }
-                } catch (error) {
-                    console.error("Error parsing attributes string:", error)
-
-                    // If JSON parsing fails, try to extract attributes using regex
-                    try {
-                        const attrRegex = /['"]([\w\d_]+)['"]:\s*([^,}]+)/g
-                        let match
-
-                        while (
-                            (match = attrRegex.exec(attributesData)) !==
-                            null
-                        ) {
-                            const [_, key] = match
-                            attributes.add(key)
-                        }
-                    } catch (regexError) {
-                        console.error(
-                            "Regex extraction failed:",
-                            regexError
-                        )
-                    }
-                }
-            } else if (
-                typeof attributesData === "object" &&
-                attributesData !== null
-            ) {
-                if (attributesData && typeof attributesData === "object") {
-                    Object.keys(attributesData).forEach((key) => {
-                        attributes.add(key)
-                    })
+                } catch {
+                    // ignore parse errors
                 }
             }
-        }
-    })
-} 
+        })
+
+        const matches = filterValue.match(/\.([a-zA-Z_][a-zA-Z0-9_]*)/g) || []
+        matches.forEach((m) => attrs.add(m.substring(1)))
+
+        setAvailableAttributes(Array.from(attrs))
+    }, [results, filterValue])
+
+    return { availableAttributes, isLoadingAttributes: false }
+}

--- a/app/vectorset/hooks/useVectorSearch.ts
+++ b/app/vectorset/hooks/useVectorSearch.ts
@@ -166,6 +166,7 @@ export function useVectorSearch({
                     searchVector: zeroVector,
                     count,
                     withEmbeddings: fetchEmbeddings,
+                    withAttributes: true,
                     filter: internalSearchState.searchFilter,
                     searchExplorationFactor: internalSearchState.searchExplorationFactor,
                     filterExplorationFactor: internalSearchState.filterExplorationFactor,
@@ -506,11 +507,12 @@ export function useVectorSearch({
             console.log("=============================================");
 
             // Perform vector-based search and measure time
-            const vsimResponse = await vsim({
-                keyName: vectorSetName!,
-                searchVector,
-                count,
-                withEmbeddings: fetchEmbeddings,
+                const vsimResponse = await vsim({
+                    keyName: vectorSetName!,
+                    searchVector,
+                    count,
+                    withEmbeddings: fetchEmbeddings,
+                    withAttributes: true,
                 filter: internalSearchState.searchFilter,
                 searchExplorationFactor: internalSearchState.searchExplorationFactor,
                 filterExplorationFactor: internalSearchState.filterExplorationFactor,
@@ -565,11 +567,12 @@ export function useVectorSearch({
 
             onStatusChange(`Element: "${internalSearchState.searchQuery}"`)
 
-            const vsimResponse = await vsim({
-                keyName: vectorSetName!,
-                searchElement: internalSearchState.searchQuery,
-                count,
-                withEmbeddings: fetchEmbeddings,
+                const vsimResponse = await vsim({
+                    keyName: vectorSetName!,
+                    searchElement: internalSearchState.searchQuery,
+                    count,
+                    withEmbeddings: fetchEmbeddings,
+                    withAttributes: true,
                 filter: internalSearchState.searchFilter,
                 searchExplorationFactor: internalSearchState.searchExplorationFactor,
                 filterExplorationFactor: internalSearchState.filterExplorationFactor,
@@ -661,6 +664,7 @@ export function useVectorSearch({
                     searchVector: vectorData,
                     count,
                     withEmbeddings: fetchEmbeddings,
+                    withAttributes: true,
                     filter: internalSearchState.searchFilter,
                     searchExplorationFactor: internalSearchState.searchExplorationFactor,
                     filterExplorationFactor: internalSearchState.filterExplorationFactor,

--- a/lib/redis-server/api.ts
+++ b/lib/redis-server/api.ts
@@ -224,6 +224,7 @@ export interface VsimRequestBody {
     count?: number
     filter?: string
     withEmbeddings?: boolean
+    withAttributes?: boolean
     searchExplorationFactor?: number
     filterExplorationFactor?: number
     returnCommandOnly?: boolean


### PR DESCRIPTION
## Summary
- add `withAttributes` flag to VSIM API
- include WITHATTRIBS in VSIM command builder
- parse attributes returned directly from VSIM
- fetch embeddings only when needed
- simplify attribute handling in VectorResults and filter hook
- always request attributes in vector search

## Testing
- `npm run lint` *(fails: many existing lint errors)*
- `npx tsc -p tsconfig.json --noEmit` *(fails: existing type errors)*